### PR TITLE
Use sveltekit's fetch in load to avoid duplicate queries & hydration delay in ssr mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,9 +276,24 @@ import { browser } from '$app/env';
 import type { Router } from '$lib/trpcServer';
 import * as trpc from '@trpc/client';
 
-const client = trpc.createTRPCClient<Router>({
-  url: browser ? '/trpc' : 'http://localhost:3000/trpc', // 👈
+const url = browser ? '/trpc' : 'http://localhost:3000/trpc';
+const client = (loadFetch?: typeof fetch) =>
+	trpc.createTRPCClient<Router>({
+		url: loadFetch ? '/trpc' : url,
+		...(loadFetch && { fetch: loadFetch }),
 });
+```
+
+Then use it like so:
+
+```ts
+// index.svelte
+export const load: Load = async ({ fetch }) => { // 👈 make sure to pass in this fetch, not the global fetch
+	const authors = await trpc(fetch).query('authors:browse', {
+		genre: 'fantasy',
+	});
+	return { props: { authors } };
+};
 ```
 
 ### Vercel's Edge Cache for Serverless Functions


### PR DESCRIPTION
### Issue:
TRPC queries are duplicated (once on the server, once on the client). Page hydration is delayed until **_both_** queries are complete. This happens when the following conditions are met:

1. The TRPC query is defined in `load`.
2. This is the first visit.
3. SSR is enabled.

Example: If you open the example repo and go to /authors, you can see the duplicate queries in the network tab of devtools. The first query is bundled up with the page HTML (server side rendering). The second query is a plain old fetch that returns JSON.

### Solution:
1. Use the [`fetch`](https://kit.svelte.dev/docs/loading#input-fetch) provided by `load`.
2. Use the same url on both the server and the client.

### Explanation:
The `fetch` provided by `load` has a feature where it would [check](https://github.com/sveltejs/kit/blob/dece3eda42161a63fb0b4ab9598516e12d6af285/packages/kit/src/runtime/client/utils.js#L132) if the call was made serverside, and if it is, it would prevent the client side call from being duplicated. It uses the url to determine whether to dedupe the calls or fire both. By using the same url (and the actual `fetch`), we can avoid the duplicate network request.

At first, I didn't notice the duplicate network call sneaking in because the data would be served with the initial document. But I'm using ChartJS on a project, and noticed that the charts had a delay before they would render. After some digging, I came to understand that it was because ChartJS uses `<canvas>`, and that the page would wait until *both* requests were completed before the canvas was rendered.

In the future, there might be an [easier way](https://github.com/sveltejs/kit/issues/2979) to accomplish this.

Also closes https://github.com/icflorescu/trpc-sveltekit-example/issues/4