### PR TITLE
make it possible to add custom pre/post response logic in handle function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add this in your SvelteKit app [hooks](https://kit.svelte.dev/docs/hooks):
 import { createTRPCHandle } from 'trpc-sveltekit';
 // create your tRPC router...
 
-export const handle = ({ event, resolve }) => {
+export const handle = async ({ event, resolve }) => {
   const response = await createTRPCHandle({ // 👈 add this handle
     url: '/trpc',
     router,

--- a/README.md
+++ b/README.md
@@ -91,12 +91,18 @@ export type Router = typeof router;
 import { createContext, responseMeta, router } from '$lib/trpcServer';
 import { createTRPCHandle } from 'trpc-sveltekit';
 
-export const handle = createTRPCHandle({
-  url: '/trpc', // optional; defaults to '/trpc'
-  router,
-  createContext, // optional
-  responseMeta, // optional
-});
+export const handle = async ({ event, resolve }) => {
+  const response = await createTRPCHandle({
+    url: '/trpc', // optional; defaults to '/trpc'
+    router,
+    createContext, // optional
+    responseMeta, // optional
+    event,
+    resolve
+  });
+
+  return response;
+};
 ```
 
 Learn more about SvelteKit hooks [here](https://kit.svelte.dev/docs/hooks).
@@ -264,21 +270,26 @@ Your server responses must [satisfy some criteria](https://vercel.com/docs/conce
 import { router } from '$lib/trpcServer';
 import { createTRPCHandle } from 'trpc-sveltekit';
 
-export const handle = createTRPCHandle({
-  url: '/trpc',
-  router,
-  responseMeta({ type, errors }) {
-    if (type === 'query' && errors.length === 0) {
-      const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
-      return {
-        headers: {
-          'cache-control': `s-maxage=1, stale-while-revalidate=${ONE_DAY_IN_SECONDS}`
-        }
-      };
+export const handle = async ({ event, resolve }) => {
+  const response = await createTRPCHandle({
+    url: '/trpc',
+    event,
+    resolve,
+    responseMeta({ type, errors }) {
+      if (type === 'query' && errors.length === 0) {
+        const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+        return {
+          headers: {
+            'cache-control': `s-maxage=1, stale-while-revalidate=${ONE_DAY_IN_SECONDS}`
+          }
+        };
+      }
+      return {};
     }
-    return {};
-  }
-});
+  });
+
+  return response;
+};
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ Add this in your SvelteKit app [hooks](https://kit.svelte.dev/docs/hooks):
 import { createTRPCHandle } from 'trpc-sveltekit';
 // create your tRPC router...
 
-export const handle = createTRPCHandle({ url: '/trpc', router }); // 👈 add this handle
+export const handle = ({ event, resolve }) => {
+  const response = await createTRPCHandle({ // 👈 add this handle
+    url: '/trpc',
+    router,
+    event,
+    resolve
+  });
+
+  return response;
+};
 ```
 
 ## How to use

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,16 +1,20 @@
+import { Handle, RequestEvent } from '@sveltejs/kit';
 import * as trpc from '@trpc/server';
 import { createTRPCHandle } from '../src';
 
 const router = trpc.router();
+const event: RequestEvent = {} as unknown as RequestEvent;
+const resolve: Parameters<Handle>[0]['resolve'] =
+	{} as unknown as Parameters<Handle>[0]['resolve'];
 
 test("Should throw when url doesn't starts with `/`", () => {
-  expect(() => {
-    createTRPCHandle({ url: 'trpc', router });
-  }).toThrowError();
+	return expect(
+		createTRPCHandle({ url: 'trpc', router, event, resolve })
+	).rejects.toThrow();
 });
 
 test('Should throw when url ends with `/`', () => {
-  expect(() => {
-    createTRPCHandle({ url: '/trpc/', router });
-  }).toThrowError();
+	return expect(
+		createTRPCHandle({ url: '/trpc/', router, event, resolve })
+	).rejects.toThrow();
 });


### PR DESCRIPTION
Closes #7 

I've been using trpc like this this for a while now so I thought I might as well create a pr.

This pr makes it possible to easily execute your own logic in your `handle` function.

```ts
// src/hooks.ts

export const handle = async ({ event, resolve }) => {
  event.locals.user = await getUserInformation(event.request.headers.get('cookie')); // 👈 like this

  const response = await createTRPCHandle({
    url: '/trpc',
    router,
    event,
    resolve
  });

  response.headers.set('x-custom-header', 'potato'); // 👈 or this
  return response;
};
```

This is a breaking change so you might want to increment the version.