### PR TITLE
Update `createContext`'s signature to accept the whole `event`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export async function createTRPCHandle<Router extends AnyRouter>({
       router,
       req,
       path: event.url.pathname.substring(url.length + 1),
-      createContext: async () => createContext?.(event.request),
+      createContext: async () => createContext?.(event),
       responseMeta,
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { RequestEvent } from '@sveltejs/kit';
 import type {
   AnyRouter,
   inferRouterContext,
@@ -8,7 +9,7 @@ import type {
 } from '@trpc/server';
 import type { TRPCResponse } from '@trpc/server/dist/declarations/src/rpc';
 
-export type CreateContextFn<TRouter extends AnyRouter> = (req: Request) => Promise<inferRouterContext<TRouter>>;
+export type CreateContextFn<TRouter extends AnyRouter> = (event: RequestEvent) => Promise<inferRouterContext<TRouter>>;
 
 export type ResponseMetaFn<TRouter extends AnyRouter> = (opts: {
   data: TRPCResponse<unknown, inferRouterError<TRouter>>[];


### PR DESCRIPTION
Instead of just passing in the `request`, it makes more sense to pass in the whole `event` to `createContext`. The main benefit is that you can reuse your existing `locals` in trpc's context.

```ts
export const createContext = async (event: RequestEvent) => {
  const user = event.locals.user; // <-- useful for authz/etc
  return { user };
};
```

Closes #12 