### PR TITLE
remove peerDependencies @sveltejs/kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "license": "ISC",
   "peerDependencies": {
-    "@sveltejs/kit": "^1.0.0-next",
     "@trpc/server": "^9.25.3"
   },
   "devDependencies": {


### PR DESCRIPTION
`yarn install --production` will install `@sveltejs/kit` if peerDependencies incldue `@sveltejs/kit`, so I delete it for smaller production dependencies size
the `@sveltejs/kit` package size is 33M, and the production dependencies size of my project is 3M