### PR TITLE
Indicate to install @trcp/client

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Learn more about SvelteKit hooks [here](https://kit.svelte.dev/docs/hooks).
 
 4. Create a [tRPC client](https://trpc.io/docs/vanilla):
 
+Install trpc client: `npm install @trpc/client`/`yarn add @trpc/client`
+
 ```ts
 // $lib/trpcClient.ts
 import type { Router } from '$lib/trpcServer'; // 👈 only the types are imported from the server


### PR DESCRIPTION
I was following this guide and `@trpc/server` was already there, after installing this package, but going into the 4th step I was missing `@trpc/client` thinking that maybe I was doing something wrong.

This line indicates that if you want to add a client you should install `@trpc/client` on your own.