### PR TITLE
Update for newest version of tRPC (v10)

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,20 +1,21 @@
 import { Handle, RequestEvent } from '@sveltejs/kit';
-import * as trpc from '@trpc/server';
+import { initTRPC } from '@trpc/server';
 import { createTRPCHandle } from '../src';
 
-const router = trpc.router();
+const t = initTRPC.create();
+const router = t.router({});
 const event: RequestEvent = {} as unknown as RequestEvent;
 const resolve: Parameters<Handle>[0]['resolve'] =
-	{} as unknown as Parameters<Handle>[0]['resolve'];
+  {} as unknown as Parameters<Handle>[0]['resolve'];
 
 test("Should throw when url doesn't starts with `/`", () => {
-	return expect(
-		createTRPCHandle({ url: 'trpc', router, event, resolve })
-	).rejects.toThrow();
+  return expect(
+    createTRPCHandle({ url: 'trpc', router, event, resolve })
+  ).rejects.toThrow();
 });
 
 test('Should throw when url ends with `/`', () => {
-	return expect(
-		createTRPCHandle({ url: '/trpc/', router, event, resolve })
-	).rejects.toThrow();
+  return expect(
+    createTRPCHandle({ url: '/trpc/', router, event, resolve })
+  ).rejects.toThrow();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@sveltejs/kit": "^1.0.0-next.515",
-        "@trpc/server": "^9.27.4",
+        "@trpc/server": "^10.0.0-rc.3",
         "@types/jest": "^29.1.2",
         "jest": "^29.1.2",
         "microbundle": "^0.15.1",
@@ -18,7 +18,7 @@
         "typescript": "^4.8.4"
       },
       "peerDependencies": {
-        "@trpc/server": "^9.27.4"
+        "@trpc/server": "^10.0.0-rc.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2636,9 +2636,9 @@
       }
     },
     "node_modules/@trpc/server": {
-      "version": "9.27.4",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.27.4.tgz",
-      "integrity": "sha512-yw0omUrxGp8+gEAuieZFeXB4bCqFvmyCDL3GOBv+Q6+cK0m5824ViHZKPgK5DYG1ijN/lbi1hP3UVKywPN7rbQ==",
+      "version": "10.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.0.0-rc.3.tgz",
+      "integrity": "sha512-aSs3uDQ5wumwVjtxj855WLDjlDC+v50QoqHzvuptI33NhJZV7meu0pU2EJkrSZXFt27CSNfP9o2ZPfoReoPUuw==",
       "dev": true
     },
     "node_modules/@trysound/sax": {
@@ -10484,9 +10484,9 @@
       }
     },
     "@trpc/server": {
-      "version": "9.27.4",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.27.4.tgz",
-      "integrity": "sha512-yw0omUrxGp8+gEAuieZFeXB4bCqFvmyCDL3GOBv+Q6+cK0m5824ViHZKPgK5DYG1ijN/lbi1hP3UVKywPN7rbQ==",
+      "version": "10.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.0.0-rc.3.tgz",
+      "integrity": "sha512-aSs3uDQ5wumwVjtxj855WLDjlDC+v50QoqHzvuptI33NhJZV7meu0pU2EJkrSZXFt27CSNfP9o2ZPfoReoPUuw==",
       "dev": true
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   },
   "license": "ISC",
   "peerDependencies": {
-    "@trpc/server": "^9.27.4"
+    "@trpc/server": "^10.0.0-rc.3"
   },
   "devDependencies": {
     "@sveltejs/kit": "^1.0.0-next.515",
-    "@trpc/server": "^9.27.4",
+    "@trpc/server": "^10.0.0-rc.3",
     "@types/jest": "^29.1.2",
     "jest": "^29.1.2",
     "microbundle": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@trpc/server": "^10.0.0-rc.3"
   },
   "devDependencies": {
-    "@sveltejs/kit": "^1.0.0-next.515",
+    "@sveltejs/kit": "^1.0.0-next.559",
     "@trpc/server": "^10.0.0-rc.3",
     "@types/jest": "^29.1.2",
     "jest": "^29.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Handle, RequestEvent } from '@sveltejs/kit';
 import type { AnyRouter, Dict } from '@trpc/server';
-import { resolveHTTPResponse } from '@trpc/server';
+import { resolveHTTPResponse } from '@trpc/server/http';
 import { CreateContextFn, ResponseMetaFn } from './types';
 
 /**


### PR DESCRIPTION
`resolveHTTPResponse` has been moved to `@trpc/server/http`. Also, the way of defining a router has changed in v10, I updated that in the README and tests.