### PR TITLE
Use `.js` file extension in ESM relative imports

### DIFF
--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,2 +1,2 @@
-export * from './client';
-export * from './server';
+export * from './client.js';
+export * from './server.js';


### PR DESCRIPTION
As per: https://www.typescriptlang.org/docs/handbook/esm-node.html#type-in-packagejson-and-new-extensions

> relative import paths need full extensions (e.g we have to write import "./foo.js" instead of import "./foo")

Version 2.X was emitting both `.mjs` and `.cjs` files, so this wasn't an issue. But it is my understanding that since version 3 only emits `.js` files and sets the `"type": "module"` package setting, relative imports in TypeScript have to use a `.js` extension.

This PR does just that. Another solution would be to revert to explicitly emitting `.mjs` and `cjs` files.