### PR TITLE
Don't run build&publish action if running on forked repo

### DIFF
--- a/.github/workflows/publish-and-deploy.yml
+++ b/.github/workflows/publish-and-deploy.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository_owner == 'icflorescu'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,6 +47,7 @@ jobs:
 
   # NPM publishing job
   publish:
+    if: github.repository_owner == 'icflorescu'
     environment:
       name: npm-registry
     runs-on: ubuntu-latest
@@ -60,6 +62,7 @@ jobs:
 
   # Pages deployment job
   deploy:
+    if: github.repository_owner == 'icflorescu'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/package/src/ValidRoute.ts
+++ b/package/src/ValidRoute.ts
@@ -16,4 +16,4 @@ type ValidateRouteEnd<T extends string> = string & {
   >}`;
 };
 
-export type ValidRoute<T extends string> = ValidateRouteStart<T, T, ValidateRouteEnd<T>>;
+export type ValidRoute<T extends string> = ValidateRouteStart<T, T, ValidateRouteEnd<T>> | "/trpc";

--- a/package/src/server.ts
+++ b/package/src/server.ts
@@ -20,7 +20,7 @@ import type { ValidRoute } from './ValidRoute';
  */
 export function createTRPCHandle<Router extends AnyRouter, URL extends string>({
   router,
-  url = '/trpc' as ValidRoute<URL>,
+  url = '/trpc',
   createContext,
   responseMeta
 }: {


### PR DESCRIPTION
Kept getting red crosses while I was updating my fork :(.

Adds an `if` to each workflow job to check if it's running on a fork, or on the main repo.

Accidentally included my `ValidRoute` fix. Shouldn't cause any issues, but double check.