### PR TITLE
Update docs and README examples with proper client initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ import { createTRPCClient, type TRPCClientInit } from 'trpc-sveltekit';
 let browserClient: ReturnType<typeof createTRPCClient<Router>>;
 
 export function trpc(init?: TRPCClientInit) {
-  if (typeof window === 'undefined') return createTRPCClient<Router>({ init });
-  if (!browserClient) browserClient = createTRPCClient<Router>();
+  const client = createTRPCClient<Router>({ init });
+  if (typeof window === 'undefined') return client;
+  if (!browserClient) browserClient = client;
   return browserClient;
 }
 ```

--- a/examples/simple/src/lib/trpc/client.ts
+++ b/examples/simple/src/lib/trpc/client.ts
@@ -1,10 +1,11 @@
 import type { Router } from '$lib/trpc/router';
 import { createTRPCClient, type TRPCClientInit } from 'trpc-sveltekit';
 
-let defaultBrowserClient: ReturnType<typeof createTRPCClient<Router>>;
+let browserClient: ReturnType<typeof createTRPCClient<Router>>;
 
 export function trpc(init?: TRPCClientInit) {
-  if (typeof window === 'undefined' || !init) return createTRPCClient<Router>({ init });
-  if (!defaultBrowserClient) defaultBrowserClient = createTRPCClient<Router>();
-  return defaultBrowserClient;
+  const client = createTRPCClient<Router>({ init });
+  if (typeof window === 'undefined') return client;
+  if (!browserClient) browserClient = client;
+  return browserClient;
 }


### PR DESCRIPTION
In our recent conversation in #59, you pointed out that the client initialization in the example was incorrect. The README instructs initialization of the client is as such:

```typescript
// lib/trpc/client.ts
import type { Router } from '$lib/trpc/router';
import { createTRPCClient, type TRPCClientInit } from 'trpc-sveltekit';

let browserClient: ReturnType<typeof createTRPCClient<Router>>;

export function trpc(init?: TRPCClientInit) {
  if (typeof window === 'undefined') return createTRPCClient<Router>({ init });
  if (!browserClient) browserClient = createTRPCClient<Router>();
  return browserClient;
}
```

However, it seems that this example does not pass the `init` parameter if initialized on the client side. This PR rewrites the `trpc` function in the docs and the README to  account for that. 

Additionally, there was a slight discrepancy between the README and the docs website, where the cached client variable was called `defaultBrowserClient` instead of `browserClient`, which has been corrected as well.