### PR TITLE
docs: fix client initialization in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ import { createTRPCClient, type TRPCClientInit } from 'trpc-sveltekit';
 let browserClient: ReturnType<typeof createTRPCClient<Router>>;
 
 export function trpc(init?: TRPCClientInit) {
+  const isBrowser = typeof window === 'undefined';
+  if (isBrowser && browserClient) return browserClient;
   const client = createTRPCClient<Router>({ init });
-  if (typeof window === 'undefined') return client;
-  if (!browserClient) browserClient = client;
-  return browserClient;
+  if (isBrowser) browserClient = client;
+  return client;
 }
 ```
 

--- a/examples/simple/src/lib/trpc/client.ts
+++ b/examples/simple/src/lib/trpc/client.ts
@@ -4,8 +4,10 @@ import { createTRPCClient, type TRPCClientInit } from 'trpc-sveltekit';
 let browserClient: ReturnType<typeof createTRPCClient<Router>>;
 
 export function trpc(init?: TRPCClientInit) {
+  const isBrowser = typeof window === 'undefined';
+  if (isBrowser && browserClient) return browserClient;
   const client = createTRPCClient<Router>({ init });
-  if (typeof window === 'undefined') return client;
-  if (!browserClient) browserClient = client;
-  return browserClient;
+  if (isBrowser) browserClient = client;
+  return client;
 }
+


### PR DESCRIPTION
I apologize for another PR on the same issue as the last one, but I really only noticed now that the client was being initialized every time on the client even if only the cached client was being returned. So now, it first checks whether it is in the browser and the `browserClient` is defined before creating a new client. 