### PR TITLE
fix: prevent from creating client if `location` is `undefined`

### DIFF
--- a/package/src/websocket/client.ts
+++ b/package/src/websocket/client.ts
@@ -7,6 +7,8 @@ import {
 import { AnyRouter } from '@trpc/server';
 
 export function createTRPCWebSocketClient<Router extends AnyRouter>() {
+  if (typeof location === 'undefined') return;
+
   const uri = `${location.protocol === 'http:' ? 'ws:' : 'wss:'}//${location.host}/trpc`;
 
   const wsClient = createWSClient({


### PR DESCRIPTION
Currently, `createTRPCWebSocketClient` relies on `location` for some properties. This isn't an issue in the example, where it is called from a function on a button press only after the component is mounted. However, if you initialize it on the top-level, it runs before the component is mounted when `location` is not defined and throws an error.

This PR simply adds a guard that returns if `location` is `undefined`.