### PR TITLE
fix: npm error EINVALIDTAGNAME

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -65,6 +65,6 @@
     "@trpc/client": ">=10",
     "@trpc/server": ">=10",
     "@types/ws": ">=8",
-    "ws": "^>=8"
+    "ws": ">=8"
   }
 }


### PR DESCRIPTION
when updating trpc-sveltekit with npm i got the following error:

```
npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "^>=8" of package "ws@^>=8": Tags may not have any characters that encodeURIComponent encodes.
```

this pull request fixes the invalid tagname