### PR TITLE
fix: Update exports map

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -31,7 +31,7 @@
   },
   "license": "ISC",
   "type": "module",
-  "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -39,15 +39,15 @@
     "LICENSE"
   ],
   "exports": {
-    ".": "./dist/index.js",
-    "./websocket": "./dist/websocket/index.js"
-  },
-  "typesVersions": {
-    "*": {
-      "websocket": [
-        "dist/websocket/index.d.ts"
-      ]
-    }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./websocket": {
+      "types": "./dist/websocket/index.d.ts",
+      "import": "./dist/websocket/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc && cp ../README.md README.md && cp ../LICENSE LICENSE",


### PR DESCRIPTION
ATTW currently has `moduleResolution` errors when used with `node16`: https://arethetypeswrong.github.io/?p=trpc-sveltekit%403.5.18

This PR adds `types` fields to the `exports` map, replacing `typesVersions`. It also replaces `main` with `module` which is more appropriate for ESM files.