### PR TITLE
Improve handle URL filtering

### DIFF
--- a/package/src/server.ts
+++ b/package/src/server.ts
@@ -69,7 +69,7 @@ export function createTRPCHandle<Router extends AnyRouter, URL extends string>({
   }) => void;
 }): Handle {
   return async ({ event, resolve }) => {
-    if (event.url.pathname.startsWith(url)) {
+    if (event.url.pathname.startsWith(url+'/')) {
       const request = event.request as Request & {
         headers: Dict<string | string[]>;
       };


### PR DESCRIPTION
Allow several handles for URLs starting with the same string. For example, "/trpc" and "/trpc2". Without testing with a trailing "/", the router for "/trpc" (if added first) handles what should be handled by the router for "/trpc2".