### PR TITLE
Update client.ts

### DIFF
--- a/examples/simple/src/lib/trpc/client.ts
+++ b/examples/simple/src/lib/trpc/client.ts
@@ -1,9 +1,10 @@
 import type { Router } from '$lib/trpc/router';
 import { createTRPCClient, type TRPCClientInit } from 'trpc-sveltekit';
 
-let browserClient: ReturnType<typeof createTRPCClient<Router>>;
+type TRPCClient = ReturnType<typeof createTRPCClient<Router>>;
+let browserClient: TRPCClient;
 
-export function trpc(init?: TRPCClientInit) {
+export function trpc(init?: TRPCClientInit): TRPCClient {
   const isBrowser = typeof window !== 'undefined';
   if (isBrowser && browserClient) return browserClient;
   const client = createTRPCClient<Router>({ init });


### PR DESCRIPTION
For some reason, type inference on this file fails during build step. Which means that if this code is put in a monorepo and becomes part of a package, the `client.d.ts` file doesn't get generated, and when `trpc` is imported, the whole type inference gets lost.

This little (mostly) documentation fix will ensure that people who come to tRPC-sveltekit, and copy code from the docs, will never encounter this issue.