### PR TITLE
tRPC v11

### DIFF
--- a/examples/bookstall/package.json
+++ b/examples/bookstall/package.json
@@ -35,8 +35,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.4.3",
+    "@trpc/server": "^11.4.3",
     "dayjs": "^1.11.13",
     "debounce": "^2.2.0",
     "hash-wasm": "^4.12.0",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -30,8 +30,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.4.3",
+    "@trpc/server": "^11.4.3",
     "delay": "^6.0.0"
   }
 }

--- a/examples/websocket/package.json
+++ b/examples/websocket/package.json
@@ -26,8 +26,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.4.3",
+    "@trpc/server": "^11.4.3",
     "delay": "^6.0.0",
     "ws": "^8.18.1"
   }

--- a/package/package.json
+++ b/package/package.json
@@ -63,15 +63,15 @@
   },
   "devDependencies": {
     "@sveltejs/kit": "^1.27.0",
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.4.3",
+    "@trpc/server": "^11.4.3",
     "@types/ws": "^8.18.0",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
     "@sveltejs/adapter-node": ">=1.2",
-    "@trpc/client": "^10.0.0",
-    "@trpc/server": "^10.0.0",
+    "@trpc/client": "^11.4.3",
+    "@trpc/server": "^11.4.3",
     "ws": ">=8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,15 +633,15 @@
     svelte-hmr "^0.15.1"
     vitefu "^0.2.4"
 
-"@trpc/client@^10.45.2":
-  version "10.45.2"
-  resolved "https://registry.yarnpkg.com/@trpc/client/-/client-10.45.2.tgz#15f9ba81303bf3417083fc6bb742e4e86b49da90"
-  integrity sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==
+"@trpc/client@^11.4.3":
+  version "11.4.3"
+  resolved "https://registry.yarnpkg.com/@trpc/client/-/client-11.4.3.tgz#0768180ede079f679408f316bbfbcb2bb88f8ba0"
+  integrity sha512-i2suttUCfColktXT8bqex5kHW5jpT15nwUh0hGSDiW1keN621kSUQKcLJ095blqQAUgB+lsmgSqSMmB4L9shQQ==
 
-"@trpc/server@^10.45.2":
-  version "10.45.2"
-  resolved "https://registry.yarnpkg.com/@trpc/server/-/server-10.45.2.tgz#5f2778c4810f93b5dc407146334f8da70a0b51fb"
-  integrity sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==
+"@trpc/server@^11.4.3":
+  version "11.4.3"
+  resolved "https://registry.yarnpkg.com/@trpc/server/-/server-11.4.3.tgz#669a964c85a0feab45da51e3ad03f63668dba525"
+  integrity sha512-wnWq3wiLlMOlYkaIZz+qbuYA5udPTLS4GVVRyFkr6aT83xpdCHyVtURT+u4hSoIrOXQM9OPCNXSXsAujWZDdaw==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"


### PR DESCRIPTION
tRPC released a v11 with some breaking changes. Creating a new major version for trpc-svelkit could be considered.