### PR TITLE
tRPC v11 (fixes breaking changes)

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -63,15 +63,15 @@
   },
   "devDependencies": {
     "@sveltejs/kit": "^1.27.0",
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.4.3",
+    "@trpc/server": "^11.4.3",
     "@types/ws": "^8.18.0",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
     "@sveltejs/adapter-node": ">=1.2",
-    "@trpc/client": "^10.0.0",
-    "@trpc/server": "^10.0.0",
+    "@trpc/client": "^11.4.3",
+    "@trpc/server": "^11.4.3",
     "ws": ">=8"
   }
 }

--- a/package/src/client.ts
+++ b/package/src/client.ts
@@ -47,7 +47,7 @@ type CreateTRPCClientOptions<Router extends AnyRouter> = (
    * A function that transforms the data before transferring it.
    * @see https://trpc.io/docs/data-transformers
    */
-  transformer?: Router['_def']['_config']['transformer'];
+  transformer?: any;
 };
 
 /**
@@ -59,7 +59,7 @@ export function createTRPCClient<Router extends AnyRouter>(
     url: '/trpc'
   }
 ) {
-  if (links) return internalCreateTRPCClient<Router>({ transformer, links });
+  if (links) return internalCreateTRPCClient<Router>({ links });
 
   if (typeof window === 'undefined' && !init) {
     throw new Error(
@@ -68,13 +68,13 @@ export function createTRPCClient<Router extends AnyRouter>(
   }
 
   return internalCreateTRPCClient<Router>({
-    transformer,
     links: [
       httpBatchLink({
         url:
           typeof window === 'undefined' ? `${init.url.origin}${url}` : `${location.origin}${url}`,
-        fetch: typeof window === 'undefined' ? init.fetch : init?.fetch ?? window.fetch,
-        headers
+        fetch: typeof window === 'undefined' ? init.fetch : (init?.fetch ?? window.fetch),
+        headers,
+        ...(transformer && { transformer })
       })
     ]
   });

--- a/package/src/websocket/client.ts
+++ b/package/src/websocket/client.ts
@@ -6,9 +6,9 @@ import {
 } from '@trpc/client';
 import { AnyRouter } from '@trpc/server';
 
-export function createTRPCWebSocketClient<Router extends AnyRouter>(): ReturnType<
-  typeof createTRPCProxyClient<Router>
-> {
+export function createTRPCWebSocketClient<Router extends AnyRouter>(opts?: {
+  transformer?: any;
+}): ReturnType<typeof createTRPCProxyClient<Router>> {
   if (typeof location === 'undefined') return;
 
   const uri = `${location.protocol === 'http:' ? 'ws:' : 'wss:'}//${location.host}/trpc`;
@@ -18,6 +18,11 @@ export function createTRPCWebSocketClient<Router extends AnyRouter>(): ReturnTyp
   });
 
   return createTRPCProxyClient<Router>({
-    links: [wsLink({ client: wsClient })]
-  } as CreateTRPCClientOptions<Router>);
+    links: [
+      wsLink({
+        client: wsClient,
+        ...(opts?.transformer && { transformer: opts.transformer })
+      })
+    ]
+  });
 }


### PR DESCRIPTION
This is a identical PR to #139 except it fixes breaking changes to get tRPC v11 to work with trpc-sveltekit.

I have also created a packaged repo for temporary use:
"trpc-sveltekit": "github:roronotalt/trpc-sveltekit-dist"

This was before i read #138 and learned about upcoming svelte support for [remote functions](https://github.com/sveltejs/kit/discussions/13897) which most people should probably just use instead.